### PR TITLE
Fixed tests id->class and added breaking example

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                 :output-dir "resources/out"
                 :optimizations :none}}
              {:id "test"
-              :source-paths ["test"]
+              :source-paths ["src" "test"]
               :compiler {
                 :output-to "resources/script/tests.js"
                 :output-dir "resources/test_out"

--- a/src/dash/core.cljs
+++ b/src/dash/core.cljs
@@ -6,7 +6,7 @@
 
 (enable-console-print!)
 
-(defn falsy [] false)
+(defn falsy [] true)
 
 (def app-state
   (atom

--- a/test/dash_test/views.cljs
+++ b/test/dash_test/views.cljs
@@ -7,7 +7,7 @@
   (reify
     om/IRender (render [_]
       (let [{:keys [id should test-fn should-be raw-fn args]} test-case]
-        (dom/div (if (= should-be (test-fn args)) #js {:id "passed"} #js {:id "failed"})
+        (dom/div (if (= should-be (test-fn args)) #js {:className "passed"} #js {:className "failed"})
           (dom/h3 nil (str "Test " id ": should " should))
           (dom/ul nil
             (if args (dom/li nil (str "given args: " args)) "")


### PR DESCRIPTION
Test divs now use `class` instead of `id` and the project file has been tweaked to use the right source dirs.
